### PR TITLE
fix build python but without EDK2_LIBC_PATH

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -99,6 +99,7 @@ jobs:
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/edk2-libc
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/edk2-test
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/SctPkg
+          set EDK2_LIBC_PATH=%WORKSPACE%/edk2-libc
           cd %WORKSPACE%\edk2
           build -a ${{ matrix.ARCH }} -t ${{ matrix.TOOLCHAIN }} -p ${{ matrix.PACKAGE }} -b ${{ matrix.TARGET }} ${{ matrix.ADDITIONAL_DEFINITION }}
 


### PR DESCRIPTION
The lastest source cannot build python anymore.
There a error when build python.
no EDK2_LIBC_PATH.
add EDK2_LIBC_PATH for fix this error.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new environment variable for the `edk2-libc` library in the Windows CI workflow, enhancing the build configuration.

### Detailed summary
- Added the line `set EDK2_LIBC_PATH=%WORKSPACE%/edk2-libc` to define the path for the `edk2-libc` library.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->