### PR TITLE
Fix python build failed

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -99,8 +99,10 @@ jobs:
       - name: Create Python package
         if: ${{ matrix.NAME == 'AppPkg' }}
         run: |-
+          export WORKSPACE=${{ github.workspace }}
+          export EDK2_LIBC_PATH=$WORKSPACE/edk2-libc
           chmod 700 edk2-libc/AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh
-          edk2-libc/AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh ${{ matrix.TOOLCHAIN }} ${{ matrix.TARGET }} ${{ matrix.ARCH }} $WORKSPACE/Build/Python368
+          edk2-libc/AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh ${{ matrix.TOOLCHAIN }} ${{ matrix.TARGET }} ${{ matrix.ARCH }} ${{ github.workspace }}/Build/Python368
 
 # Ref to AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { NAME: 'AppPkg',         PACKAGE: 'AppPkg/AppPkg.dsc',                                     TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'GCC',       ADDITIONAL_DEFINITION: '' },
-          { NAME: 'AppPkg',         PACKAGE: 'AppPkg/AppPkg.dsc',                                     TARGET: 'DEBUG',   ARCH: 'X64',     TOOLCHAIN: 'GCC',       ADDITIONAL_DEFINITION: '' },
+          { NAME: 'AppPkg',         PACKAGE: 'AppPkg/AppPkg.dsc',                                     TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'GCC',       ADDITIONAL_DEFINITION: '-D BUILD_PYTHON368' },
+          { NAME: 'AppPkg',         PACKAGE: 'AppPkg/AppPkg.dsc',                                     TARGET: 'DEBUG',   ARCH: 'X64',     TOOLCHAIN: 'GCC',       ADDITIONAL_DEFINITION: '-D BUILD_PYTHON368' },
           { NAME: 'ShellPkg',       PACKAGE: 'ShellPkg/ShellPkg.dsc',                                 TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'GCC',       ADDITIONAL_DEFINITION: '' },
           { NAME: 'FatPkg',         PACKAGE: 'FatPkg/FatPkg.dsc',                                     TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'GCC',       ADDITIONAL_DEFINITION: '' },
           { NAME: 'Ext4Pkg',        PACKAGE: 'Features/Ext4Pkg/Ext4Pkg.dsc',                          TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'GCC',       ADDITIONAL_DEFINITION: '' },
@@ -58,7 +58,6 @@ jobs:
         if: ${{ matrix.NAME == 'AppPkg' }}
         run: |-
           pushd $PWD && cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8 && python srcprep.py && popd
-          sed -i 's+# AppPkg/Applications/Python/Python-3.6.8/Python368.inf+AppPkg/Applications/Python/Python-3.6.8/Python368.inf+1' edk2-libc/AppPkg/AppPkg.dsc
 
       - name: Customize Patches for ShellPkg
         if: ${{ matrix.NAME == 'ShellPkg' }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -82,6 +82,7 @@ jobs:
           export GCC_X64_PREFIX=x86_64-linux-gnu-
           export GCC_AARCH64_PREFIX=aarch64-linux-gnu-
           export WORKSPACE=${{ github.workspace }}
+          export EDK2_LIBC_PATH=$WORKSPACE/edk2-libc
           ln -s edk2-test/uefi-sct/SctPkg/ SctPkg
           export PACKAGES_PATH=$WORKSPACE/edk2
           export PACKAGES_PATH=$PACKAGES_PATH:$WORKSPACE/edk2-platforms

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ matrix.NAME == 'AppPkg' }}
         run: |-
           pushd $PWD && cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8 && python srcprep.py && popd
-          sed -i "s|Build/|\$WORKSPACE/Build/|g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.sh
+          sed -i "s|Build/|\$WORKSPACE/Build/|g" edk2-libc/AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh
 
       - name: Customize Patches for ShellPkg
         if: ${{ matrix.NAME == 'ShellPkg' }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -54,10 +54,11 @@ jobs:
           cp edk2/BaseTools/BinWrappers/PosixLike/GenCrc32 edk2/BaseTools/BinWrappers/PosixLike/GenBin
           chmod a+x edk2/BaseTools/BinWrappers/PosixLike/GenBin
 
-      - name: Patch for Python mod(Use for AppPkg Uefi Python support)
+      - name: Prepare environment for Python EFI
         if: ${{ matrix.NAME == 'AppPkg' }}
         run: |-
           pushd $PWD && cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8 && python srcprep.py && popd
+          sed -i "s|Build/|\$WORKSPACE/Build/|g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.sh
 
       - name: Customize Patches for ShellPkg
         if: ${{ matrix.NAME == 'ShellPkg' }}
@@ -95,6 +96,11 @@ jobs:
           . edk2/edksetup.sh
           build -a ${{ matrix.ARCH }} -t ${{ matrix.TOOLCHAIN }} -p ${{ matrix.PACKAGE }} -b ${{ matrix.TARGET }} ${{ matrix.ADDITIONAL_DEFINITION }}
 
+      - name: Create Python package
+        if: ${{ matrix.NAME == 'AppPkg' }}
+        run: |-
+          edk2-libc/AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh ${{ matrix.TOOLCHAIN }} ${{ matrix.TARGET }} ${{ matrix.ARCH }} $WORKSPACE/Build/Python368
+
 # Ref to AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.NAME == 'AppPkg' }}
@@ -109,8 +115,7 @@ jobs:
             Build/SETUPLOG.*
             Build/UPDATE*.*
             Build/**/AutoGen.*
-            edk2-libc/AppPkg/Applications/Python/Python-3.6.8/Lib/
-            edk2-libc/StdLib/Efi/StdLib/etc/
+            Build/Python368/**
 
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.NAME != 'AppPkg' }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Create Python package
         if: ${{ matrix.NAME == 'AppPkg' }}
         run: |-
+          chmod 700 edk2-libc/AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh
           edk2-libc/AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh ${{ matrix.TOOLCHAIN }} ${{ matrix.TARGET }} ${{ matrix.ARCH }} $WORKSPACE/Build/Python368
 
 # Ref to AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
           set path=%path%;${{ github.workspace }}\utilities\sed;
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
-          sed -i "s+Build\\\\+%WORKSPACE%\\\\Build\\\\+g" edk2-libc/AppPkg/Applications/Python\Python-3.6.8/create_python_pkg.bat
+          sed -i "s+Build\\\\+%WORKSPACE%\\\\Build\\\\+g" edk2-libc/AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg
         shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
           set path=%path%;${{ github.workspace }}\utilities\sed;
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
-          sed -i "s|Build\\|\%WORKSPACE\%\\Build\\|g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
+          sed -i "s+Build\\+\%WORKSPACE\%\\Build\\+g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg
         shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -111,7 +111,9 @@ jobs:
         shell: cmd
         if: ${{ matrix.NAME == 'AppPkg' }}
         run: |-
-          %WORKSPACE%\edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat ${{ matrix.TOOLCHAIN }} ${{ matrix.TARGET }} ${{ matrix.ARCH }} %WORKSPACE%\Build\Python368
+          set WORKSPACE=${{ github.workspace }}
+          set EDK2_LIBC_PATH=%WORKSPACE%\edk2-libc
+          %WORKSPACE%\edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat ${{ matrix.TOOLCHAIN }} ${{ matrix.TARGET }} ${{ matrix.ARCH }} ${{ github.workspace }}\Build\Python368
 
 # Ref to AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
           set path=%path%;${{ github.workspace }}\utilities\sed;
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
-          sed -i "s+Build\\+\%WORKSPACE\%\\Build\\+g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
+          sed -i "s+Build\\+^%WORKSPACE^%\\Build\\+g" edk2-libc/AppPkg/Applications/Python\Python-3.6.8/create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg
         shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
           set path=%path%;${{ github.workspace }}\utilities\sed;
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
-          sed -i "s+Build\\+%%WORKSPACE%%\\Build\\+g" edk2-libc/AppPkg/Applications/Python\Python-3.6.8/create_python_pkg.bat
+          sed -i "s+Build\\+%WORKSPACE%\\Build\\+g" edk2-libc/AppPkg/Applications/Python\Python-3.6.8/create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg
         shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -99,6 +99,7 @@ jobs:
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/edk2-libc
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/edk2-test
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/SctPkg
+          set EDK2_LIBC_PATH=%WORKSPACE%/edk2-libc
           cd %WORKSPACE%\edk2
           build -a ${{ matrix.ARCH }} -t ${{ matrix.TOOLCHAIN }} -p ${{ matrix.PACKAGE }} -b ${{ matrix.TARGET }} ${{ matrix.ADDITIONAL_DEFINITION }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
           set path=%path%;${{ github.workspace }}\utilities\sed;
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
-          sed -i "s+Build\\\\+%WORKSPACE%\\\\Build\\\\+g" edk2-libc/AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.bat
+          sed -i "s+Build\\\\+%WORKSPACE%\\\\Build\\\\+g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg
         shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { NAME: 'AppPkg',         PACKAGE: 'AppPkg/AppPkg.dsc',                                     TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '' },
-          { NAME: 'AppPkg',         PACKAGE: 'AppPkg/AppPkg.dsc',                                     TARGET: 'DEBUG',   ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '' },
+          { NAME: 'AppPkg',         PACKAGE: 'AppPkg/AppPkg.dsc',                                     TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '-D BUILD_PYTHON368' },
+          { NAME: 'AppPkg',         PACKAGE: 'AppPkg/AppPkg.dsc',                                     TARGET: 'DEBUG',   ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '-D BUILD_PYTHON368' },
           { NAME: 'ShellPkg',       PACKAGE: 'ShellPkg/ShellPkg.dsc',                                 TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '' },
           { NAME: 'FatPkg',         PACKAGE: 'FatPkg/FatPkg.dsc',                                     TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '' },
           { NAME: 'AsixPkg',        PACKAGE: 'Drivers/ASIX/Asix.dsc',                                 TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '' },
@@ -23,6 +23,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: Setup build environment
         shell: cmd
@@ -62,7 +67,6 @@ jobs:
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
           cd ${{ github.workspace }}
-          sed -i 's+# AppPkg/Applications/Python/Python-3.6.8/Python368.inf+AppPkg/Applications/Python/Python-3.6.8/Python368.inf+1' edk2-libc/AppPkg/AppPkg.dsc
 
       - name: Customize Patches for ShellPkg
         shell: cmd
@@ -99,7 +103,6 @@ jobs:
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/edk2-libc
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/edk2-test
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/SctPkg
-          set EDK2_LIBC_PATH=%WORKSPACE%/edk2-libc
           cd %WORKSPACE%\edk2
           build -a ${{ matrix.ARCH }} -t ${{ matrix.TOOLCHAIN }} -p ${{ matrix.PACKAGE }} -b ${{ matrix.TARGET }} ${{ matrix.ADDITIONAL_DEFINITION }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -59,14 +59,14 @@ jobs:
           make
           xcopy /S edk2\BaseTools\BinWrappers\WindowsLike/GenCrc32 edk2\BaseTools\BinWrappers\WindowsLike\GenBin\
 
-      - name: Patch for Python mod(Use for AppPkg Uefi Python support)
+      - name: Prepare environment for Python EFI
         shell: cmd
         if: ${{ matrix.NAME == 'AppPkg' }}
         run: |-
           set path=%path%;${{ github.workspace }}\utilities\sed;
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
-          cd ${{ github.workspace }}
+          sed -i "s|Build\\|\%WORKSPACE\%\\Build\\|g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg
         shell: cmd
@@ -94,7 +94,7 @@ jobs:
           call ${{ github.workspace }}\utilities\vsenv.bat x64
           call ${{ github.workspace }}\edk2\edksetup.bat ${{ matrix.TOOLCHAIN }}
           set WORKSPACE=${{ github.workspace }}
-          set EDK2_LIBC_PATH=%WORKSPACE%/edk2-libc
+          set EDK2_LIBC_PATH=%WORKSPACE%\edk2-libc
           mklink /D SctPkg edk2-test\uefi-sct\SctPkg
           set PACKAGES_PATH=%WORKSPACE%/edk2
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/edk2-platforms
@@ -106,6 +106,12 @@ jobs:
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/SctPkg
           cd %WORKSPACE%\edk2
           build -a ${{ matrix.ARCH }} -t ${{ matrix.TOOLCHAIN }} -p ${{ matrix.PACKAGE }} -b ${{ matrix.TARGET }} ${{ matrix.ADDITIONAL_DEFINITION }}
+
+      - name: Create Python package
+        shell: cmd
+        if: ${{ matrix.NAME == 'AppPkg' }}
+        run: |-
+          %WORKSPACE%\edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat ${{ matrix.TOOLCHAIN }} ${{ matrix.TARGET }} ${{ matrix.ARCH }} %WORKSPACE%\Build\Python368
 
 # Ref to AppPkg/Applications/Python/Python-3.6.8/create_python_pkg.sh
       - uses: actions/upload-artifact@v4
@@ -121,8 +127,7 @@ jobs:
             Build/SETUPLOG.*
             Build/UPDATE*.*
             Build/**/AutoGen.*
-            edk2-libc/AppPkg/Applications/Python/Python-3.6.8/Lib/
-            edk2-libc/StdLib/Efi/StdLib/etc/
+            Build/Python368/**
 
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.NAME != 'AppPkg' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
           set path=%path%;${{ github.workspace }}\utilities\sed;
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
-          sed -i "s+Build\\+^%WORKSPACE^%\\Build\\+g" edk2-libc/AppPkg/Applications/Python\Python-3.6.8/create_python_pkg.bat
+          sed -i "s+Build\\+%%WORKSPACE%%\\Build\\+g" edk2-libc/AppPkg/Applications/Python\Python-3.6.8/create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg
         shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,7 +68,7 @@ jobs:
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
           popd
-          sed -i "s+Build\\\\+%WORKSPACE%\\\\Build\\\\+g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
+          sed -i "s+Build\\\\+\%WORKSPACE\%\\\\Build\\\\+g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
           cat edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,6 +69,7 @@ jobs:
           python srcprep.py
           popd
           sed -i "s+Build\\\\+%WORKSPACE%\\\\Build\\\\+g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
+          cat edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg
         shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
           set path=%path%;${{ github.workspace }}\utilities\sed;
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
-          sed -i "s+Build\\+%WORKSPACE%\\Build\\+g" edk2-libc/AppPkg/Applications/Python\Python-3.6.8/create_python_pkg.bat
+          sed -i "s+Build\\\\+%WORKSPACE%\\\\Build\\\\+g" edk2-libc/AppPkg/Applications/Python\Python-3.6.8/create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg
         shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,6 +94,7 @@ jobs:
           call ${{ github.workspace }}\utilities\vsenv.bat x64
           call ${{ github.workspace }}\edk2\edksetup.bat ${{ matrix.TOOLCHAIN }}
           set WORKSPACE=${{ github.workspace }}
+          set EDK2_LIBC_PATH=%WORKSPACE%/edk2-libc
           mklink /D SctPkg edk2-test\uefi-sct\SctPkg
           set PACKAGES_PATH=%WORKSPACE%/edk2
           set PACKAGES_PATH=%PACKAGES_PATH%;%WORKSPACE%/edk2-platforms

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -64,8 +64,10 @@ jobs:
         if: ${{ matrix.NAME == 'AppPkg' }}
         run: |-
           set path=%path%;${{ github.workspace }}\utilities\sed;
+          pushd %CD%
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
+          popd
           sed -i "s+Build\\\\+%WORKSPACE%\\\\Build\\\\+g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,7 +68,7 @@ jobs:
           cd edk2-libc/AppPkg/Applications/Python/Python-3.6.8
           python srcprep.py
           popd
-          sed -i "s+Build\\\\+\%WORKSPACE\%\\\\Build\\\\+g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
+          sed -i "s+Build\\\\+%%WORKSPACE%%\\\\Build\\\\+g" edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
           cat edk2-libc\AppPkg\Applications\Python\Python-3.6.8\create_python_pkg.bat
 
       - name: Customize Patches for ShellPkg


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the CI configuration for `AppPkg` in both `ubuntu.yml` and `windows.yml` workflows to support building with Python 3.6.8. It introduces new environment variables, modifies existing commands, and adds steps for creating a Python package.

### Detailed summary
- Added `-D BUILD_PYTHON368` to `ADDITIONAL_DEFINITION` for `AppPkg` in both workflows.
- Changed the name of the patch step to `Prepare environment for Python EFI`.
- Updated `sed` commands to modify paths for Python package creation.
- Introduced a new step to create the Python package in both workflows.
- Set `EDK2_LIBC_PATH` environment variable in both workflows.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->