### PR TITLE
Support build Sct packages

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,6 +17,8 @@ jobs:
           { NAME: 'AsixPkg',        PACKAGE: 'Drivers/ASIX/Asix.dsc',                                 TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '' },
           { NAME: 'DisplayLinkPkg', PACKAGE: 'Drivers/DisplayLink/DisplayLinkPkg/DisplayLinkPkg.dsc', TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '' },
           { NAME: 'OvmfPkg',        PACKAGE: 'OvmfPkg/OvmfPkgX64.dsc',                                TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '' },
+          { NAME: 'UefiSct',        PACKAGE: 'SctPkg/UEFI/UEFI_SCT.dsc',                              TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '' },
+          { NAME: 'IhvSct',         PACKAGE: 'SctPkg/UEFI/IHV_SCT.dsc',                               TARGET: 'RELEASE', ARCH: 'X64',     TOOLCHAIN: 'VS2019',       ADDITIONAL_DEFINITION: '' },
         ]
     steps:
       - name: Checkout repositories
@@ -50,14 +52,17 @@ jobs:
 
       - name: Build/Patch GenBin(Use for SctPkg)
         shell: cmd
-        if: ${{ matrix.NAME == 'SctPkg' }}
+        if: ${{ matrix.NAME == 'UefiSct' || matrix.NAME == 'IhvSct' }}
         run: |-
           set path=%path%;${{ github.workspace }}\utilities\sed;
           xcopy /S edk2-test\uefi-sct\SctPkg\Tools\Source\GenBin edk2\BaseTools\Source\C\GenBin\
           sed -i 's+$(EDK_TOOLS_PATH)/Source/C+..+1' edk2/BaseTools/Source/C/GenBin/GNUmakefile
-          cd edk2\BaseTools\Source\C\GenBin
-          make
-          xcopy /S edk2\BaseTools\BinWrappers\WindowsLike/GenCrc32 edk2\BaseTools\BinWrappers\WindowsLike\GenBin\
+          cd ${{ github.workspace }}\edk2\BaseTools\Source\C\GenBin
+          nmake
+          xcopy /S edk2\BaseTools\BinWrappers\WindowsLike\GenFds.bat edk2\BaseTools\BinWrappers\WindowsLike\GenBin.bat
+          cd ${{ github.workspace }}\edk2-test
+          git fetch origin pull/265/head:pr-265
+          git checkout pr-265
 
       - name: Prepare environment for Python EFI
         shell: cmd
@@ -110,6 +115,20 @@ jobs:
           cd %WORKSPACE%\edk2
           build -a ${{ matrix.ARCH }} -t ${{ matrix.TOOLCHAIN }} -p ${{ matrix.PACKAGE }} -b ${{ matrix.TARGET }} ${{ matrix.ADDITIONAL_DEFINITION }}
 
+      - name: Create UefiSct packages
+        shell: cmd
+        if: ${{ matrix.NAME == 'UefiSct' }}
+        run: |-
+          cd ${{ github.workspace }}\Build\UefiSct\${{ matrix.TARGET }}_${{ matrix.TOOLCHAIN }}
+          ..\..\..\SctPkg\CommonGenFramework.bat uefi_sct ${{ matrix.ARCH }} Install${{ matrix.ARCH }}.efi
+
+      - name: Create IhvSct packages
+        shell: cmd
+        if: ${{ matrix.NAME == 'IhvSct' }}
+        run: |-
+          cd ${{ github.workspace }}\Build\IhvSct\${{ matrix.TARGET }}_${{ matrix.TOOLCHAIN }}
+          ..\..\..\SctPkg\CommonGenFramework.bat ihv_sct ${{ matrix.ARCH }} Install${{ matrix.ARCH }}.efi
+
       - name: Create Python package
         shell: cmd
         if: ${{ matrix.NAME == 'AppPkg' }}
@@ -135,7 +154,22 @@ jobs:
             Build/Python368/**
 
       - uses: actions/upload-artifact@v4
-        if: ${{ matrix.NAME != 'AppPkg' }}
+        if: ${{ matrix.NAME == 'UefiSct' || matrix.NAME == 'IhvSct' }}
+        with:
+          name: edk2_${{ matrix.NAME }}_${{ matrix.TARGET }}_${{ matrix.TOOLCHAIN }}_${{ matrix.ARCH }}_${{ github.sha }}
+          retention-days: 14
+          path: |-
+            Build/**/*.efi
+            Build/**/FV/*.fd
+            Build/BUILDLOG*.*
+            Build/CI_*.*
+            Build/SETUPLOG.*
+            Build/UPDATE*.*
+            Build/**/AutoGen.*
+            Build/**/SctPackageX64/*.*
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ matrix.NAME != 'AppPkg' && matrix.NAME != 'UefiSct' && matrix.NAME != 'IhvSct' }}
         with:
           name: edk2_${{ matrix.NAME }}_${{ matrix.TARGET }}_${{ matrix.TOOLCHAIN }}_${{ matrix.ARCH }}_${{ github.sha }}
           retention-days: 14

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
 ### Clone repositories
 
 ```bash
-git clone --recursive -j -1 -v https://github.com/saqwed/myedk2.git myedk2
+git clone --recursive -j4 -v https://github.com/saqwed/myedk2.git myedk2
 ```
 
 ### (Optional) Patch tools_def.txt for cross compiler
@@ -80,7 +80,7 @@ build -a X64 -t GCC -p ShellPkg/ShellPkg.dsc -b RELEASE
 ### Clone repositories
 
 ```batch
-git clone --recursive -j -1 -v https://github.com/saqwed/myedk2.git myedk2
+git clone --recursive -j4 -v https://github.com/saqwed/myedk2.git myedk2
 ```
 
 ### Setup edk2 build environment


### PR DESCRIPTION
This pull request updates the Windows workflow configuration to include new build targets for `UefiSct` and `IhvSct` packages, refines artifact upload logic, and modifies the repository cloning command in the `README.md` for better performance. Below are the most important changes grouped by theme.

### Workflow configuration updates:
* Added `UefiSct` and `IhvSct` build targets to the matrix configuration in `.github/workflows/windows.yml`.
* Updated the conditional logic for the `Build/Patch GenBin` step to support `UefiSct` and `IhvSct` instead of the previous `SctPkg`.
* Introduced new steps to create packages for `UefiSct` and `IhvSct`, including specific commands for generating framework files.
* Refined artifact upload logic to handle `UefiSct` and `IhvSct` artifacts separately, ensuring proper retention and file path handling.

### Documentation update:
* Updated the repository cloning command in `README.md` to use `-j4` for parallelism, improving clone performance. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R83)