### PR TITLE
Remove pr-265 on edk2-test and use the latest edk2-test

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,9 +62,6 @@ jobs:
           cd ${{ github.workspace }}\edk2\BaseTools\Source\C\GenBin
           nmake
           copy ${{ github.workspace }}\edk2\BaseTools\BinWrappers\WindowsLike\GenFds.bat ${{ github.workspace }}\edk2\BaseTools\BinWrappers\WindowsLike\GenBin.bat
-          cd ${{ github.workspace }}\edk2-test
-          git fetch origin pull/265/head:pr-265
-          git checkout pr-265
 
       - name: Prepare environment for Python EFI
         shell: cmd


### PR DESCRIPTION
This pull request makes adjustments to the build process and updates a submodule reference. The most important changes include removing unnecessary steps in the Windows workflow and updating the `edk2-test` submodule to a new commit.

### Build process adjustments:
* [`.github/workflows/windows.yml`](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cL65-L67): Removed steps related to fetching and checking out a specific pull request (`pr-265`) from the `edk2-test` repository, streamlining the workflow.

### Submodule update:
* [`edk2-test`](diffhunk://#diff-ff780c7d77bbdd30eb10a0315401f8d4a895dc1941e34de13b52be5d37772982L1-R1): Updated the submodule reference from commit `40cc44e557fbebb0319bc30b1dfdaca7072f7260` to `b5707921e1b19c17fcce3a2b1a1f7c729cdbc4c3`.